### PR TITLE
test: verify hostname output in make test

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,3 +16,5 @@ jobs:
         run: make
       - name: make all
         run: make all
+      - name: make test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,13 @@ lib$(NAME).so.1: $(NAME).c
 	$(CC) -fPIC -rdynamic -g -Wall -shared -Wl,-soname,$@ -lc -ldl -o $@ $<
 
 test:
-	LD_PRELOAD=$(PWD)/lib$(NAME).so.1 NEWHOSTNAME=my_host_name hostname
+	@out=`LD_PRELOAD=$(PWD)/lib$(NAME).so.1 NEWHOSTNAME=my_host_name hostname`; \
+	if [ "$$out" = "my_host_name" ]; then \
+	echo "hostname output matches my_host_name"; \
+	else \
+	echo "expected my_host_name but got $$out"; \
+	exit 1; \
+	fi
 
 clean:
 	-rm -f lib$(NAME).so.1


### PR DESCRIPTION
## Summary
- improve `test` recipe to check hostname output
- run `make test` in CI workflow

## Testing
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684cbae93f988328a542ab3294995cbf