### PR TITLE
Fix README sentence punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![C/C++ CI](https://github.com/elulcao/gethostname/actions/workflows/c-cpp.yml/badge.svg)](https://github.com/elulcao/gethostname/actions/workflows/c-cpp.yml)
 
-gethostname is a package to mock the gethostname() Sys call with a custom host name The gethostname() Sys call is intercepted via LD_PRELOAD before other libs are loaded.
+gethostname is a package to mock the gethostname() system call with a custom host name. The gethostname() system call is intercepted via LD_PRELOAD before other libs are loaded.
 
 The main intention of this change is to allow Host Names with "_" characters.
 


### PR DESCRIPTION
## Summary
- fix punctuation for the package description in README

## Testing
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684cbae3ffa883289e9769c2b88efb58